### PR TITLE
Fixes to Torch Widget

### DIFF
--- a/src/net/cactii/flash2/TorchWidgetProvider.java
+++ b/src/net/cactii/flash2/TorchWidgetProvider.java
@@ -1,4 +1,3 @@
-
 package net.cactii.flash2;
 
 import android.app.Activity;
@@ -13,7 +12,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.widget.RemoteViews;
 
 import java.util.List;
@@ -21,9 +19,6 @@ import java.util.List;
 public class TorchWidgetProvider extends AppWidgetProvider {
 
     private static TorchWidgetProvider sInstance;
-
-    private static final ComponentName THIS_APPWIDGET = new ComponentName("net.cactii.flash2",
-            "net.cactii.flash2.TorchWidgetProvider");
 
     static synchronized TorchWidgetProvider getInstance() {
         if (sInstance == null) {
@@ -33,22 +28,13 @@ public class TorchWidgetProvider extends AppWidgetProvider {
     }
 
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
-        final int N = appWidgetIds.length;
-        for (int i = 0; i < N; i++) {
-            int appWidgetId = appWidgetIds[i];
-            RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget);
-
-            views.setOnClickPendingIntent(R.id.btn, getLaunchPendingIntent(context, appWidgetId, 0));
-
-            this.updateState(context, appWidgetId);
-            appWidgetManager.updateAppWidget(appWidgetId, views);
-        }
+        for (int appWidgetId : appWidgetIds)
+        	this.updateState(context, appWidgetId);
     }
 
     private static PendingIntent getLaunchPendingIntent(Context context, int appWidgetId,
             int buttonId) {
         Intent launchIntent = new Intent();
-        Log.d("TorchWidget", "WIdget id: " + appWidgetId);
         launchIntent.setClass(context, TorchWidgetProvider.class);
         launchIntent.addCategory(Intent.CATEGORY_ALTERNATIVE);
         launchIntent.setData(Uri.parse("custom:" + appWidgetId + "/" + buttonId));
@@ -72,7 +58,6 @@ public class TorchWidgetProvider extends AppWidgetProvider {
             widgetId = Integer.parseInt(data.getSchemeSpecificPart().split("/")[0]);
             buttonId = Integer.parseInt(data.getSchemeSpecificPart().split("/")[1]);
 
-            Log.d("TorchWidget", "Button Id is: " + widgetId);
             if (buttonId == 0) {
 
                 if (this.TorchServiceRunning(context)) {
@@ -113,8 +98,7 @@ public class TorchWidgetProvider extends AppWidgetProvider {
 
         if (!(svcList.size() > 0))
             return false;
-        for (int i = 0; i < svcList.size(); i++) {
-            RunningServiceInfo serviceInfo = svcList.get(i);
+        for (RunningServiceInfo serviceInfo : svcList) {
             ComponentName serviceName = serviceInfo.service;
             if (serviceName.getClassName().endsWith(".TorchService")
                     || serviceName.getClassName().endsWith(".RootTorchService"))
@@ -125,14 +109,19 @@ public class TorchWidgetProvider extends AppWidgetProvider {
 
     public void updateAllStates(Context context) {
         final AppWidgetManager am = AppWidgetManager.getInstance(context);
-        for (int id : am.getAppWidgetIds(THIS_APPWIDGET))
+        int[] appWidgetIds = am.getAppWidgetIds(
+                new ComponentName(context, this.getClass()));
+        for (int id : appWidgetIds){
             this.updateState(context, id);
+        }
     }
 
     public void updateState(Context context, int appWidgetId) {
-        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget);
+    	RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
+        views.setOnClickPendingIntent(R.id.btn, getLaunchPendingIntent(context, appWidgetId, 0));
+        
         if (this.TorchServiceRunning(context)) {
             views.setImageViewResource(R.id.img_torch, R.drawable.icon);
         } else {

--- a/src/net/cactii/flash2/WidgetOptionsActivity.java
+++ b/src/net/cactii/flash2/WidgetOptionsActivity.java
@@ -1,4 +1,3 @@
-
 package net.cactii.flash2;
 
 import android.appwidget.AppWidgetManager;
@@ -12,7 +11,6 @@ import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
-import android.util.Log;
 
 public class WidgetOptionsActivity extends PreferenceActivity implements
         OnSharedPreferenceChangeListener {
@@ -32,7 +30,6 @@ public class WidgetOptionsActivity extends PreferenceActivity implements
         if (extras != null) {
             mAppWidgetId = extras.getInt(AppWidgetManager.EXTRA_APPWIDGET_ID,
                     AppWidgetManager.INVALID_APPWIDGET_ID);
-            Log.d("TorchOptions", "Widget id: " + mAppWidgetId);
         }
 
         CheckBoxPreference mBrightPref = (CheckBoxPreference) findPreference("widget_bright");
@@ -59,6 +56,31 @@ public class WidgetOptionsActivity extends PreferenceActivity implements
                 editor.putBoolean("widget_bright_" + mAppWidgetId,
                         mPreferences.getBoolean("widget_bright", false));
                 editor.commit();
+
+                //Initialize widget view for first update
+                Context context = getApplicationContext();
+                RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget);
+                Intent launchIntent = new Intent();
+                launchIntent.setClass(context, TorchWidgetProvider.class);
+                launchIntent.addCategory(Intent.CATEGORY_ALTERNATIVE);
+                launchIntent.setData(Uri.parse("custom:" + mAppWidgetId + "/0"));
+                PendingIntent pi = PendingIntent.getBroadcast(context, 0 /*
+                                                                          * no
+                                                                          * requestCode
+                                                                          */, launchIntent, 0 /*
+                                                                                               * no
+                                                                                               * flags
+                                                                                               */);
+                views.setOnClickPendingIntent(R.id.btn, pi);
+                if (mPreferences.getBoolean("widget_strobe_" + mAppWidgetId, false))
+                    views.setTextViewText(R.id.ind, "Strobe");
+                else if (mPreferences.getBoolean("widget_bright_" + mAppWidgetId, false))
+                    views.setTextViewText(R.id.ind, "Bright");
+                else
+                    views.setTextViewText(R.id.ind, "Torch");
+                final AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+                appWidgetManager.updateAppWidget(mAppWidgetId, views);
+
                 Intent resultValue = new Intent();
                 resultValue.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, mAppWidgetId);
                 setResult(RESULT_OK, resultValue);


### PR DESCRIPTION
I hope this is an acceptable way to offer changes to this application. (Should I be using repo and such? Please forgive my ignorance.)

The enclosed commits fix Issue 2043, and also make the widget initialize correctly. I have plans to fix Issues 1787 and 2203, as long as you find (some of) the enclosed changes acceptable, as I think I've basically figured out the underlying problem.

Indeed, these issue all share a loss of widget functionality following a screen rotation or restart of the Launcher. In these circumstances, it seems that the widget is rebuilt using the last view passed to it through the AppWidgetManager.updateAppWidget call. Thus, whenever the widget's view is updated, it is important to pass it a complete view with all desired elements included. In the Torch widget, for example, it used to be that first the main button was linked using one view (and then updateAppWidget was called), then the images and text were set using a second view (together with a second update... call). Thus, when the widget was rebuilt after a screen rotation, the button functionality was lost.

I hope at least some of this is useful - you can reach me at jason.m.asher@gmail.com.
